### PR TITLE
Add CNAME to gh-pages branch on deploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ after_success: |
   [ $TRAVIS_BRANCH = master ] &&
   [ $TRAVIS_PULL_REQUEST = false ] &&
   zola build &&
+  cp CNAME public/ &&
   sudo pip install ghp-import &&
   ghp-import -n public &&
   git push -fq https://${GITHUB_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git gh-pages


### PR DESCRIPTION
In order to deploy to GitHub Pages, I'm force-pushing to the `gh-pages` branch, which has the effect of erasing branch history on each successful build of master. While GitHub was looking for a `CNAME` marker file in that branch, the file was nowhere to be found.

This caused GitHub to drop our custom domain configuration on each successful deploy. So while the build was good, nobody would see it if they went to cogoldrust.com. With this PR, the `CNAME` marker file is copied manually.