### PR TITLE
Correctly use img srcset attribute to display hi-dpi images

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -159,6 +159,10 @@ ul.yearbook li {
     margin-bottom: 2em;
     margin-right: 0;
   }
+
+  ul.yearbook li:last-child {
+    margin-bottom: 0;
+  }
 }
 
 ul.yearbook li:last-child {

--- a/templates/about.html
+++ b/templates/about.html
@@ -20,7 +20,11 @@
     {% for org in page.extra.organizers %}
       <li>
         <a href="{{ org[2] }}">
-          <img src="{{ resize_image(path=org[1], width=200, height=200, quality=80, op="fill") }}" class="portrait">
+          <img srcset="{{ resize_image(path=org[1], width=200, height=200, quality=80, op="fill") }} 1x 
+                       {{ resize_image(path=org[1], width=400, height=400, quality=80, op="fill") }} 2x"
+               src="{{ resize_image(path=org[1], width=400, height=400, quality=80, op="fill") }}"
+               alt="Avatar for conference organizer {{ org[0] }}"
+               class="portrait">
           <h3>{{ org[0] }}</h3>
         </a>
       </li>


### PR DESCRIPTION
Avatar images were previously blurry on hi-dpi screens. This PR corrects the fuzziness while minimizing bandwidth usage.