### PR TITLE
Add Fathom analytics

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -80,5 +80,18 @@
         &copy; {{ config.extra.copyright }}
       </p>
     {% endblock footer %}
+  <script>
+    (function(f, a, t, h, o, m){
+      a[h]=a[h]||function(){
+        (a[h].q=a[h].q||[]).push(arguments)
+      };
+      o=f.createElement('script'),
+      m=f.getElementsByTagName('script')[0];
+      o.async=1; o.src=t; o.id='fathom-script';
+      m.parentNode.insertBefore(o,m)
+    })(document, window, '//fathom.uptime.ventures/tracker.js', 'fathom');
+    fathom('set', 'siteId', 'UGQIR');
+    fathom('trackPageview');
+  </script>
 </body>
 </html>


### PR DESCRIPTION
Many developers (including myself) have ad blocking software enabled. This means Google Analytics scripts never load, unless a specific allowance is made by the user.

This PR adds support for an open source analytics system called Fathom. To mitigate ad blockers, our instance is available at https://fathom.uptime.ventures, a domain alias that we can change if this system proves useful enough to keep around.